### PR TITLE
[bug fix] fix hive partition cannot overwrite

### DIFF
--- a/connectors/connector-hive/hive-bridge/src/main/java/org/apache/flink/connectors/hive/InputOutputFormat.java
+++ b/connectors/connector-hive/hive-bridge/src/main/java/org/apache/flink/connectors/hive/InputOutputFormat.java
@@ -54,7 +54,7 @@ public class InputOutputFormat {
 	}
 
 	public static OutputFormat <Row> createOutputFormat(
-		Catalog catalog, DynamicTableFactory.Context context, Map <String, String> partitions) {
+		Catalog catalog, DynamicTableFactory.Context context, Map <String, String> partitions, Boolean overwriteSink) {
 
 		if (!(catalog instanceof HiveCatalog)) {
 			throw new RuntimeException("Catalog should be hive catalog.");
@@ -71,6 +71,8 @@ public class InputOutputFormat {
 		if (partitions != null) {
 			hiveTableSink.applyStaticPartition(partitions);
 		}
+
+        hiveTableSink.applyOverwrite(overwriteSink);
 
 		return hiveTableSink.getOutputFormat();
 	}

--- a/core/src/main/java/com/alibaba/alink/common/io/catalog/HiveCatalog.java
+++ b/core/src/main/java/com/alibaba/alink/common/io/catalog/HiveCatalog.java
@@ -833,6 +833,7 @@ public class HiveCatalog extends BaseCatalog {
 		return factory.doAsThrowRuntime(() -> {
 
 			String partitionSpec = params.get(HiveCatalogParams.PARTITION);
+            boolean overwriteSink = params.get(HiveCatalogParams.OVERWRITE_SINK);
 
 			Map <String, String> partitions = null;
 			if (!StringUtils.isNullOrWhitespaceOnly(partitionSpec)) {
@@ -844,10 +845,10 @@ public class HiveCatalog extends BaseCatalog {
 				true, Thread.currentThread().getContextClassLoader()
 			);
 
-			Method method = inputOutputFormat.getMethod("createOutputFormat", Catalog.class, DynamicTableFactory.Context.class, Map.class);
+			Method method = inputOutputFormat.getMethod("createOutputFormat", Catalog.class, DynamicTableFactory.Context.class, Map.class, Boolean.class);
 
 			OutputFormat<Row> internalRet =
-				(OutputFormat <Row>) method.invoke(null, catalog, context, partitions);
+				(OutputFormat <Row>) method.invoke(null, catalog, context, partitions, overwriteSink);
 
 			return new RichOutputFormatWithClassLoader(factory, internalRet);
 		});


### PR DESCRIPTION
when we set the `HiveCatalogParams.OVERWRITE_SINK = true`, It doesn't work. This PR fix it. We can set `HiveCatalogParams.OVERWRITE_SINK = true` to overwrite the partition.