### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-common to 3.2.4

### DIFF
--- a/connectors/connector-parquet-0.11/pom.xml
+++ b/connectors/connector-parquet-0.11/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>alink_connectors</artifactId>
         <groupId>com.alibaba.alink</groupId>
@@ -29,7 +27,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>2.8.0</version>
+            <version>3.2.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/plugins/xgboost-bridge/pom.xml
+++ b/plugins/xgboost-bridge/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>alink_plugins</artifactId>
         <groupId>com.alibaba.alink</groupId>
@@ -41,7 +39,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.3.2</version>
+            <version>3.2.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/shaded_libraries/third_party_flink_ai_extended/pom.xml
+++ b/shaded_libraries/third_party_flink_ai_extended/pom.xml
@@ -1,5 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
     <parent>
         <groupId>com.alibaba.alink</groupId>
@@ -66,7 +66,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <grpc.version>1.13.2</grpc.version>
         <log4j.version>2.17.1</log4j.version>
-        <hadoop.version>2.8.0</hadoop.version>
+        <hadoop.version>3.2.4</hadoop.version>
         <tensorflow.version>1.15.0</tensorflow.version>
         <tensorflow2.version>2.3.1</tensorflow2.version>
         <tensorflow.package.name>tensorflow</tensorflow.package.name>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-common 2.8.0
- [CVE-2017-15713](https://www.oscs1024.com/hd/CVE-2017-15713)


### What did I do？
Upgrade org.apache.hadoop:hadoop-common from 2.8.0 to 3.2.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` succeeded locally.
Run `mvn clean test` succeeded locally. all tests passed.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS